### PR TITLE
remove backpack from CAS pilot

### DIFF
--- a/co47_ADR_Blue_Shark.Altis/functions/fn_enemyCAS.sqf
+++ b/co47_ADR_Blue_Shark.Altis/functions/fn_enemyCAS.sqf
@@ -38,6 +38,7 @@ if ((count enemyCasArray) < _jetLimit) then {
 	_jetActual allowCrewInImmobile TRUE;
 	_jetActual flyInHeight 1000;
 	_jetActual lock 2;
+	removeBackpackGlobal _jetPilot;
 	_jetPilot assignAsDriver _jetActual;
 	_jetPilot moveInDriver _jetActual;
 	


### PR DESCRIPTION
У пилота вражеского штурмовика достаточно удалить парашют, тогда живым он не приземлится.
#450
